### PR TITLE
close #3: using uint64 since binlog may grow larger than 4 Gigabytes.

### DIFF
--- a/get_gtid_of_binlog.go
+++ b/get_gtid_of_binlog.go
@@ -16,12 +16,12 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 	}
 	defer file.Close()
 
-	p := uint64(4)
+	p := int64(4)
 	headerBs := make([]byte, 19)
 	gtidBs := make([]byte, 25)
 
 	for {
-		if _, err := file.Seek(int64(p), 0); nil != err {
+		if _, err := file.Seek(p, 0); nil != err {
 			if "EOF" == err.Error() {
 				break
 			}
@@ -39,7 +39,7 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 		eventType := int(headerBs[4])
 
 		if GTID_LOG_EVENT != eventType {
-			p += uint64(length)
+			p += int64(length)
 			continue
 		}
 
@@ -56,7 +56,7 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 			return gtidDesc, err
 		}
 
-		p += uint64(length)
+		p += int64(length)
 	}
 	return gtidDesc, nil
 }

--- a/get_gtid_of_binlog.go
+++ b/get_gtid_of_binlog.go
@@ -2,10 +2,11 @@ package mysql_binlog_utils
 
 import (
 	"encoding/binary"
-	gtid "github.com/ikarishinjieva/go-gtid"
 	"io"
 	"os"
 	"strconv"
+
+	gtid "github.com/ikarishinjieva/go-gtid"
 )
 
 func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
@@ -15,7 +16,7 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 	}
 	defer file.Close()
 
-	p := uint32(4)
+	p := uint64(4)
 	headerBs := make([]byte, 19)
 	gtidBs := make([]byte, 25)
 
@@ -38,7 +39,7 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 		eventType := int(headerBs[4])
 
 		if GTID_LOG_EVENT != eventType {
-			p += length
+			p += uint64(length)
 			continue
 		}
 
@@ -55,7 +56,7 @@ func GetGtidOfBinlog(binlogPath string) (gtidDesc string, err error) {
 			return gtidDesc, err
 		}
 
-		p += length
+		p += uint64(length)
 	}
 	return gtidDesc, nil
 }

--- a/get_previous_gtid.go
+++ b/get_previous_gtid.go
@@ -14,12 +14,12 @@ func GetPreviousGtids(binlogPath string) (gtidDesc string, err error) {
 	}
 	defer file.Close()
 
-	p := uint64(4)
+	p := int64(4)
 	headerBs := make([]byte, 19)
 	payloadBs := make([]byte, 1024)
 
 	for {
-		if _, err := file.Seek(int64(p), 0); nil != err {
+		if _, err := file.Seek(p, 0); nil != err {
 			if "EOF" == err.Error() {
 				break
 			}
@@ -37,7 +37,7 @@ func GetPreviousGtids(binlogPath string) (gtidDesc string, err error) {
 		eventType := int(headerBs[4])
 
 		if PREVIOUS_GTIDS_LOG_EVENT != eventType {
-			p += uint64(length)
+			p += int64(length)
 			continue
 		}
 

--- a/get_previous_gtid.go
+++ b/get_previous_gtid.go
@@ -14,7 +14,7 @@ func GetPreviousGtids(binlogPath string) (gtidDesc string, err error) {
 	}
 	defer file.Close()
 
-	p := uint32(4)
+	p := uint64(4)
 	headerBs := make([]byte, 19)
 	payloadBs := make([]byte, 1024)
 
@@ -37,7 +37,7 @@ func GetPreviousGtids(binlogPath string) (gtidDesc string, err error) {
 		eventType := int(headerBs[4])
 
 		if PREVIOUS_GTIDS_LOG_EVENT != eventType {
-			p += length
+			p += uint64(length)
 			continue
 		}
 

--- a/get_unexecuted_binlog_pos_by_gtid.go
+++ b/get_unexecuted_binlog_pos_by_gtid.go
@@ -16,13 +16,13 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 	}
 	defer file.Close()
 
-	p := uint64(4)
+	p := int64(4)
 	headerBs := make([]byte, 19)
 	payloadBs := make([]byte, 1024)
-	lastExecutedGtidPos := uint64(0)
+	lastExecutedGtidPos := int64(0)
 
 	for {
-		if _, err := file.Seek(int64(p), 0); nil != err {
+		if _, err := file.Seek(p, 0); nil != err {
 			return 0, err
 		}
 
@@ -34,7 +34,7 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 		eventType := int(headerBs[4])
 
 		if GTID_LOG_EVENT != eventType {
-			p += uint64(length)
+			p += int64(length)
 			continue
 		}
 
@@ -56,7 +56,7 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 		}
 		if contain {
 			lastExecutedGtidPos = p
-			p += uint64(length)
+			p += int64(length)
 		} else {
 			retPos := p
 			if includeEventBeforeFirst && 0 != lastExecutedGtidPos {

--- a/get_unexecuted_binlog_pos_by_gtid.go
+++ b/get_unexecuted_binlog_pos_by_gtid.go
@@ -2,10 +2,11 @@ package mysql_binlog_utils
 
 import (
 	"encoding/binary"
-	gtid "github.com/ikarishinjieva/go-gtid"
 	"io"
 	"os"
 	"strconv"
+
+	gtid "github.com/ikarishinjieva/go-gtid"
 )
 
 func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, includeEventBeforeFirst bool) (pos uint, err error) {
@@ -15,10 +16,10 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 	}
 	defer file.Close()
 
-	p := uint32(4)
+	p := uint64(4)
 	headerBs := make([]byte, 19)
 	payloadBs := make([]byte, 1024)
-	lastExecutedGtidPos := uint32(0)
+	lastExecutedGtidPos := uint64(0)
 
 	for {
 		if _, err := file.Seek(int64(p), 0); nil != err {
@@ -33,7 +34,7 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 		eventType := int(headerBs[4])
 
 		if GTID_LOG_EVENT != eventType {
-			p += length
+			p += uint64(length)
 			continue
 		}
 
@@ -55,7 +56,7 @@ func GetUnexecutedBinlogPosByGtid(binlogPath string, executedGtidDesc string, in
 		}
 		if contain {
 			lastExecutedGtidPos = p
-			p += length
+			p += uint64(length)
 		} else {
 			retPos := p
 			if includeEventBeforeFirst && 0 != lastExecutedGtidPos {


### PR DESCRIPTION
fixing issue #3 